### PR TITLE
schema: AcceptanceCriteria + ExpertActivationProfileStage + Optional TrainStage fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /rust/target/
+
+# Python build / bytecode
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/

--- a/python/forge_alloy/domains/__init__.py
+++ b/python/forge_alloy/domains/__init__.py
@@ -1,0 +1,75 @@
+"""forge_alloy.domains — registered vocabularies for the universal core.
+
+Each domain extension is a registered vocabulary for one universe of
+data transformation pipelines. Adding a new domain (photo-provenance,
+ticketing, delivery, compute-receipt, ...) is exactly one new file in
+this package + one import line below. The universal forge_alloy.types
+core never changes when a new domain ships.
+
+Architectural rule: NEVER add domain-specific stage types or root
+extension fields to forge_alloy/types.py. The dependency direction is
+strict: extensions → core, never core → extensions. The bd4349d
+checkpoint commit on the domain-extensibility-refactor branch was the
+wrong-layered first attempt (ML fields bolted into the universal core);
+this package is the correct layer.
+
+Currently registered:
+    llm-forge          ML model forging (the morning's qwen3-coder-30b-a3b
+                       artifact and the rest of the continuum-ai/* catalog
+                       all declare this domain implicitly)
+    photo-provenance   stub — camera enclave → edits → publish chain
+    ticketing          stub — venue tickets, FedEx delivery, concerts
+
+Stubs exist as witnesses that the registry handles non-ML domains. When
+real photo-provenance or ticketing artifacts ship, the stubs get filled
+in with concrete Pydantic schemas.
+"""
+
+from .base import DomainExtension
+from .registry import DomainRegistry
+
+# Module-level singleton — the canonical registry the universal core
+# composes its discriminated stage union from at validation time.
+_REGISTRY = DomainRegistry()
+
+
+def register_domain(ext_class: type[DomainExtension]) -> type[DomainExtension]:
+    """Register a DomainExtension subclass with the singleton."""
+    return _REGISTRY.register(ext_class)
+
+
+def resolve_domain(domain_id: str) -> DomainExtension:
+    """Look up and instantiate the domain extension for an id string.
+
+    Used by the universal core when validating an alloy whose domains[]
+    field declares this id. Raises KeyError with a clear message naming
+    what IS registered if the id isn't known — loud failure pointing
+    at the missing extension file.
+    """
+    return _REGISTRY.resolve(domain_id)
+
+
+def registered_domains() -> list[str]:
+    """All registered domain id strings, sorted."""
+    return _REGISTRY.domains()
+
+
+# Importing each concrete extension module triggers the register() call
+# below. Order doesn't matter; the registry is keyed by id, not by import
+# order. NEW domain = new module + new import line + new register() call.
+from . import llm_forge          # noqa: E402,F401
+from . import photo_provenance   # noqa: E402,F401
+from . import ticketing          # noqa: E402,F401
+
+_REGISTRY.register(llm_forge.LlmForgeDomain)
+_REGISTRY.register(photo_provenance.PhotoProvenanceDomain)
+_REGISTRY.register(ticketing.TicketingDomain)
+
+
+__all__ = [
+    "DomainExtension",
+    "DomainRegistry",
+    "register_domain",
+    "resolve_domain",
+    "registered_domains",
+]

--- a/python/forge_alloy/domains/base.py
+++ b/python/forge_alloy/domains/base.py
@@ -1,0 +1,65 @@
+"""DomainExtension ABC — the contract every forge-alloy domain extension satisfies.
+
+A domain extension is a registered vocabulary for one universe of data
+transformation pipelines:
+
+    llm-forge          ML model forging (prune, train, expert-prune, quant, eval, ...)
+    photo-provenance   Camera enclave → edits → publish chain (capture, edit, publish)
+    ticketing          Venue ticket batches (issued, transferred, scanned)
+    delivery           Package waypoints (picked-up, in-transit, delivered)
+    compute-receipt    Grid job receipts (job-submitted, completed, attested)
+
+The universal forge-alloy core knows nothing about any specific domain.
+It enforces the Merkle chain-of-custody walk and the integrity attestation
+surface. The vocabulary for "what stages exist" comes from the registered
+domain extensions, not from the core.
+
+Each extension owns:
+    - id:                a string the alloy's domains[] field carries
+    - stage_types():     dict of stage type name → Pydantic model class
+                         (the schemas the alloy's stages[] entries validate against)
+    - root_extensions(): dict of root field name → Pydantic model class
+                         (additional fields this domain adds at the alloy root)
+
+Concrete extensions live in sibling files: llm_forge.py, photo_provenance.py,
+ticketing.py, etc. Each registers itself with the singleton in __init__.py
+on package import.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class DomainExtension(ABC):
+    """Abstract base for one domain's vocabulary."""
+
+    # Subclass MUST set this — the string the alloy's domains[] field carries.
+    # Examples: 'llm-forge', 'photo-provenance', 'ticketing', 'delivery'.
+    id: str = ""
+
+    @abstractmethod
+    def stage_types(self) -> dict[str, type]:
+        """Return the stage type registry for this domain.
+
+        Maps stage type strings (the alloy's stages[].type field) to
+        Pydantic model classes that validate the stage's params. The
+        universal core's discriminated stage union is composed from
+        the union of every registered domain's stage_types().
+        """
+        ...
+
+    @abstractmethod
+    def root_extensions(self) -> dict[str, type]:
+        """Return the root-extension field registry for this domain.
+
+        Maps root field names (e.g. 'priorMetricBaselines',
+        'calibrationCorpora') to Pydantic model classes. These fields
+        are additions to the alloy root that this domain owns; the
+        universal core ignores them.
+        """
+        ...
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} id={self.id!r}>"

--- a/python/forge_alloy/domains/llm_forge.py
+++ b/python/forge_alloy/domains/llm_forge.py
@@ -1,0 +1,162 @@
+"""llm-forge — the ML model forging domain extension.
+
+This domain owns the entire vocabulary for forging ML models: prune,
+train, lora, expert-prune, expert-activation-profile, compensation-lora,
+context-extend, modality, quant, eval, publish, package, deploy, deliver,
+source-config. It also owns the §4.1.3.4 falsifiability anchor structures
+(PriorMetricBaseline) and the §4.1.3.4.1 calibration-corpus discipline
+gate structures (CalibrationCorpusRef).
+
+Relationship to forge_alloy.types (the universal core):
+    The bd4349d checkpoint commit on this branch bolted ML-specific
+    fields directly into types.py — that was the wrong layer. The
+    correct architecture is: types.py is a domain-agnostic envelope
+    (Merkle chain of custody, integrity attestation, source/target,
+    publication metadata), and EVERY ML-specific concept lives here in
+    llm_forge.py.
+
+    Today, this module RE-EXPORTS the ML types from types.py to satisfy
+    the LlmForgeDomain.stage_types() contract while consumers (sentinel-ai,
+    Continuum's Factory widget) still import from forge_alloy directly.
+    The full extraction (moving the actual class definitions out of
+    types.py and into this file) is a follow-up commit that lands as
+    a pure refactor — every cached alloy still validates because the
+    re-exported names are identical.
+
+    The dependency direction is strict: extensions → core, never
+    core → extensions. types.py NEVER imports from forge_alloy.domains.
+    This is enforced by test_universal_core_does_not_import_llm_forge
+    in test_domain_extension_layout.py.
+
+Reproducibility contract: this domain extension MUST stay frozen against
+the published continuum-ai/* alloy catalog. New ML methodology arrives
+as NEW stage types or NEW alloy field discriminators registered here,
+NEVER as edits to existing type definitions. The 17 published artifacts
+all validate against the current contract; any change that breaks even
+one of them is wrong.
+"""
+
+from __future__ import annotations
+
+from .base import DomainExtension
+
+# Re-export from the universal core's current location. The class
+# definitions live in forge_alloy/types.py today (the bd4349d checkpoint
+# state); this module re-exports them so the public API surface is
+# stable while the universal-core extraction lands as a separate
+# refactor commit. Consumers can import from EITHER:
+#     from forge_alloy import ExpertPruneStage          (legacy public API)
+#     from forge_alloy.domains.llm_forge import ExpertPruneStage   (new path)
+# Both resolve to the same class object today.
+from ..types import (
+    # Stage types (transform, input, output, bookend)
+    SourceConfigStage,
+    PruneStage,
+    TrainStage,
+    LoRAStage,
+    CompactStage,
+    QuantStage,
+    PackageStage,
+    EvalStage,
+    PublishStage,
+    DeployStage,
+    ExpertPruneStage,
+    ExpertActivationProfileStage,
+    CompensationLoRAStage,
+    ContextExtendStage,
+    ModalityStage,
+    # Result types
+    BenchmarkResult,
+    BenchmarkDef,
+    HardwareProfile,
+    GenerationSample,
+    AlloyResults,
+    # § 4.1.3.4 falsifiability + discipline gate structures
+    PriorMetricBaseline,
+    CalibrationCorpusRef,
+    # Hardware tier
+    AlloyHardware,
+)
+
+
+class LlmForgeDomain(DomainExtension):
+    """The llm-forge domain extension. Registered against id 'llm-forge'."""
+
+    id = "llm-forge"
+
+    def stage_types(self) -> dict[str, type]:
+        """Stage types this domain owns. Used by the universal core's
+        discriminated stage union when an alloy declares this domain in
+        its domains[] field."""
+        return {
+            "source-config":             SourceConfigStage,
+            "prune":                     PruneStage,
+            "train":                     TrainStage,
+            "lora":                      LoRAStage,
+            "compact":                   CompactStage,
+            "quant":                     QuantStage,
+            "package":                   PackageStage,
+            "eval":                      EvalStage,
+            "publish":                   PublishStage,
+            "deploy":                    DeployStage,
+            "expert-prune":              ExpertPruneStage,
+            "expert-activation-profile": ExpertActivationProfileStage,
+            "compensation-lora":         CompensationLoRAStage,
+            "context-extend":            ContextExtendStage,
+            "modality":                  ModalityStage,
+            # 'deliver' is a legacy alias used by older alloys for what is
+            # now called 'publish' — both resolve to PublishStage so the
+            # legacy alloys keep validating without a separate stage class.
+            "deliver":                   PublishStage,
+        }
+
+    def root_extensions(self) -> dict[str, type]:
+        """Root-extension fields this domain adds to the alloy root.
+
+        These are the §4.1.3.4 / §4.1.3.4.1 structures from the
+        methodology paper:
+
+            calibrationCorpora    list[CalibrationCorpusRef]
+                                  hash-pinned calibration corpora used by
+                                  any expert-activation-profile or
+                                  compensation-lora stage in this alloy
+            priorMetricBaselines  list[PriorMetricBaseline]
+                                  superseded forge attempts preserved as
+                                  falsifiability anchors (the §4.1.3.4
+                                  negative-baseline pattern)
+        """
+        return {
+            "calibrationCorpora":   CalibrationCorpusRef,
+            "priorMetricBaselines": PriorMetricBaseline,
+        }
+
+
+__all__ = [
+    "LlmForgeDomain",
+    # Stage types (re-exported for callers that import from this module)
+    "SourceConfigStage",
+    "PruneStage",
+    "TrainStage",
+    "LoRAStage",
+    "CompactStage",
+    "QuantStage",
+    "PackageStage",
+    "EvalStage",
+    "PublishStage",
+    "DeployStage",
+    "ExpertPruneStage",
+    "ExpertActivationProfileStage",
+    "CompensationLoRAStage",
+    "ContextExtendStage",
+    "ModalityStage",
+    # Result types
+    "BenchmarkResult",
+    "BenchmarkDef",
+    "HardwareProfile",
+    "GenerationSample",
+    "AlloyResults",
+    "AlloyHardware",
+    # § 4.1.3.4 structures
+    "PriorMetricBaseline",
+    "CalibrationCorpusRef",
+]

--- a/python/forge_alloy/domains/photo_provenance.py
+++ b/python/forge_alloy/domains/photo_provenance.py
@@ -1,0 +1,63 @@
+"""photo-provenance — Camera enclave → edits → publish chain of custody.
+
+Stub domain that proves the registry mechanism is genuinely non-ML. The
+photo-provenance use case from forge-alloy's APPLICATIONS.md:
+
+    A camera enclave signs the original capture (capture stage), every
+    edit in Photoshop / Lightroom / Affinity Photo records a signed
+    edit stage with the operation type and the editor's enclave key,
+    and the publish step on social media records the final stage with
+    the QR code embedded in EXIF. Anyone with the alloy can walk the
+    full chain of custody from sensor to feed and verify cryptographically
+    that no edit happened off-chain.
+
+The actual stage schemas are placeholders today — when the first real
+photo-provenance use case ships, this file gets the real Pydantic models
+for capture / edit / publish stages and a real CameraAttestation +
+EditAttestation root extension. For now the stub is a witness that the
+registry handles non-ML domains without any change to the universal core
+or to llm_forge.
+
+Reproducibility contract: photo-provenance alloys are NOT in the test
+catalog yet (no published artifacts use this domain). When they ship,
+add them to the regression test alongside the continuum-ai/* alloys.
+"""
+
+from __future__ import annotations
+
+from .base import DomainExtension
+
+
+class PhotoProvenanceDomain(DomainExtension):
+    """photo-provenance domain extension. Registered against id 'photo-provenance'."""
+
+    id = "photo-provenance"
+
+    def stage_types(self) -> dict[str, type]:
+        """Stage types this domain owns. Currently empty stubs.
+
+        Real schemas would be:
+            capture       → CameraCaptureStage
+                            (sensorId, gpsHash, exif, signature)
+            edit          → PhotoEditStage
+                            (tool, operation, parameters, signature)
+            publish       → PhotoPublishStage
+                            (platform, postId, qrEmbed, signature)
+
+        The stage type strings are placeholders pending the first real
+        photo-provenance artifact's schema.
+        """
+        return {
+            # Placeholder — concrete schemas land when the first
+            # photo-provenance artifact ships.
+        }
+
+    def root_extensions(self) -> dict[str, type]:
+        """Root-extension fields. Currently empty.
+
+        Future:
+            cameraAttestation  → CameraAttestation
+                                 (enclave certificate, public key,
+                                  attestation timestamp)
+        """
+        return {}

--- a/python/forge_alloy/domains/registry.py
+++ b/python/forge_alloy/domains/registry.py
@@ -1,0 +1,63 @@
+"""DomainRegistry — domain id string → DomainExtension class lookup.
+
+Mirror of scripts/adapters/registry.py and scripts/eval_runners/registry.py
+in sentinel-ai. Same shape: strict exact-match dispatch on the id string,
+idempotent registration of the same class, raise on a different class
+against an existing id (silent shadowing is the f-word pattern), clear
+KeyError listing what IS registered when an unknown id is requested.
+"""
+
+from __future__ import annotations
+
+from .base import DomainExtension
+
+
+class DomainRegistry:
+    """id → DomainExtension class lookup."""
+
+    def __init__(self) -> None:
+        self._domains: dict[str, type[DomainExtension]] = {}
+
+    def register(self, ext_class: type[DomainExtension]) -> type[DomainExtension]:
+        """Register a DomainExtension subclass under its `id` class attribute.
+
+        Idempotent for the same class. Raises ValueError if a DIFFERENT
+        class is registered against an existing id (silent override would
+        let one extension shadow another and is exactly the kind of
+        unfindable-bug surface the no-fallback rule prohibits).
+        """
+        domain_id = getattr(ext_class, "id", "")
+        if not domain_id:
+            raise ValueError(
+                f"{ext_class.__name__} has no .id class attribute — set it "
+                f"to the domain id string this extension answers to."
+            )
+        existing = self._domains.get(domain_id)
+        if existing is not None and existing is not ext_class:
+            raise ValueError(
+                f"domain id {domain_id!r} is already registered to "
+                f"{existing.__name__}; cannot also register {ext_class.__name__}. "
+                f"If this is a vocabulary upgrade, register under a NEW id "
+                f"so old alloys still resolve to the original extension for "
+                f"reproducibility."
+            )
+        self._domains[domain_id] = ext_class
+        return ext_class
+
+    def resolve(self, domain_id: str) -> DomainExtension:
+        """Look up the extension for a domain id and instantiate it."""
+        ext_class = self._domains.get(domain_id)
+        if ext_class is None:
+            registered = sorted(self._domains.keys())
+            raise KeyError(
+                f"no DomainExtension registered for id={domain_id!r}. "
+                f"Registered domains: {registered}. To add a new domain, "
+                f"create forge_alloy/domains/<id>.py with a DomainExtension "
+                f"subclass that sets id = '{domain_id}', then import it "
+                f"from forge_alloy/domains/__init__.py."
+            )
+        return ext_class()
+
+    def domains(self) -> list[str]:
+        """All registered domain id strings, sorted."""
+        return sorted(self._domains.keys())

--- a/python/forge_alloy/domains/ticketing.py
+++ b/python/forge_alloy/domains/ticketing.py
@@ -1,0 +1,50 @@
+"""ticketing — Venue ticket batches with cryptographic chain of custody.
+
+Stub domain that proves the registry mechanism handles non-ML use cases
+beyond photo-provenance too. The ticketing use case from forge-alloy's
+APPLICATIONS.md:
+
+    A venue's box office issues a batch of tickets (issued stage), each
+    transfer between users records a signed transferred stage, and the
+    gate scanner records the final stage at admission (scanned). The
+    alloy carries the full chain of custody from issuer to gate, so a
+    counterfeit ticket can be detected by walking the chain and
+    verifying every signature is from a key that was authorized at
+    that step.
+
+Same shape as photo-provenance: stub today, real Pydantic models when
+the first real ticketing artifact ships.
+
+Reproducibility contract: ticketing alloys are NOT in the test catalog
+yet. When the first venue / FedEx / concert use case lands, the schemas
+get filled in and the regression test grows to cover them.
+"""
+
+from __future__ import annotations
+
+from .base import DomainExtension
+
+
+class TicketingDomain(DomainExtension):
+    """ticketing domain extension. Registered against id 'ticketing'."""
+
+    id = "ticketing"
+
+    def stage_types(self) -> dict[str, type]:
+        """Stage types this domain owns. Currently empty stubs.
+
+        Real schemas would be:
+            issued         → TicketIssuedStage
+                             (venue, eventId, seat, holder,
+                              issuerSignature, issuedAt)
+            transferred    → TicketTransferredStage
+                             (fromHolder, toHolder, fromSignature,
+                              toSignature, transferredAt)
+            scanned        → TicketScannedStage
+                             (gate, scannerId, scannerSignature,
+                              admit | deny, scannedAt)
+        """
+        return {}
+
+    def root_extensions(self) -> dict[str, type]:
+        return {}

--- a/python/forge_alloy/types.py
+++ b/python/forge_alloy/types.py
@@ -14,22 +14,54 @@ class AlloySource(BaseModel):
     is_moe: bool = Field(default=False, alias="isMoE")
     total_experts: Optional[int] = Field(default=None, alias="totalExperts")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 # ── Results (populated after execution) ────────────────────────────────────
 
 
 class BenchmarkResult(BaseModel):
-    """A single benchmark result. Metrics are open-ended — each benchmark
-    reports whatever it wants (passing, total, accuracy, score, etc.)"""
+    """A single benchmark result. Carries the canonical fields the publish
+    pipeline (alloy_to_card.py) and the Tier 4 reproducibility test both
+    consume:
+
+        score          The student's pass@1 / accuracy / etc.
+        baseScore      The unmodified base anchor's same metric, measured on
+                       the same hardware in the same eval pipeline (per the
+                       § 4.1.4.1 anchor-reproduction discipline gate).
+        delta          score - baseScore (preserved in the alloy so the
+                       published Δ doesn't drift if either side is rounded).
+        metric         The metric name (typically 'pass@1' for code benchmarks).
+        samplesPath    The per-problem JSONL the student score was computed
+                       from. Tier 3 hashes this against resultHash.
+        baseSamplesPath The base anchor's samples JSONL.
+        resultHash     sha256 of the student samples bytes (Merkle anchor).
+        baseResultHash sha256 of the base samples bytes.
+        calibrated     True if the score is the calibration-anchored value
+                       per § 4.1.4.1 discipline.
+
+    Plus the legacy `metrics` open-ended dict for benchmarks that report
+    multiple sub-scores (e.g. lm-eval-harness MMLU sub-tasks).
+    """
     name: str
     subset: Optional[str] = None
+    metric: Optional[str] = None
+    score: Optional[float] = None
+    base_score: Optional[float] = Field(default=None, alias="baseScore")
+    delta: Optional[float] = None
+    calibrated: Optional[bool] = None
+    samples_path: Optional[str] = Field(default=None, alias="samplesPath")
+    base_samples_path: Optional[str] = Field(default=None, alias="baseSamplesPath")
+    result_hash: Optional[str] = Field(default=None, alias="resultHash")
+    base_result_hash: Optional[str] = Field(default=None, alias="baseResultHash")
     metrics: dict[str, Union[int, float, str, bool]] = Field(default_factory=dict)
     submitted_to_leaderboard: bool = Field(default=False, alias="submittedToLeaderboard")
-    result_hash: Optional[str] = Field(default=None, alias="resultHash")
 
-    model_config = {"populate_by_name": True}
+    # extra="allow" so artifact-specific extras (per-benchmark notes,
+    # methodology anchor URLs, etc.) round-trip cleanly. The named fields
+    # above are the canonical surface that publish_model.py and
+    # alloy_to_card.py read.
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class HardwareProfile(BaseModel):
@@ -42,7 +74,7 @@ class HardwareProfile(BaseModel):
     memory_usage_gb: Optional[float] = Field(default=None, alias="memoryUsageGb")
     verified: bool = False
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class GenerationSample(BaseModel):
@@ -52,7 +84,7 @@ class GenerationSample(BaseModel):
     completion: str
     baseline_completion: Optional[str] = Field(default=None, alias="baselineCompletion")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class CodeAttestation(BaseModel):
@@ -65,7 +97,7 @@ class CodeAttestation(BaseModel):
     environment: Optional[str] = None
     environment_hash: Optional[str] = Field(default=None, alias="environmentHash")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class DatasetAttestation(BaseModel):
@@ -75,7 +107,7 @@ class DatasetAttestation(BaseModel):
     hash: str
     source: Optional[str] = None
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class AttestationSignature(BaseModel):
@@ -89,7 +121,7 @@ class AttestationSignature(BaseModel):
     certificate_chain: list[str] = Field(default_factory=list, alias="certificateChain")
     key_registry: Optional[str] = Field(default=None, alias="keyRegistry")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class IntegrityAttestation(BaseModel):
@@ -127,7 +159,7 @@ class AdapterAttestation(BaseModel):
     commit: Optional[str] = None
     attested_at: str = Field(alias="attestedAt")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class TrustAnchor(BaseModel):
@@ -138,7 +170,7 @@ class TrustAnchor(BaseModel):
     anchored_at: Optional[str] = Field(default=None, alias="anchoredAt")
     network: Optional[str] = None
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class AlloyResults(BaseModel):
@@ -151,12 +183,21 @@ class AlloyResults(BaseModel):
     improvement_pct: Optional[float] = Field(default=None, alias="improvementPct")
     final_size_gb: Optional[float] = Field(default=None, alias="finalSizeGb")
     final_params: Optional[str] = Field(default=None, alias="finalParams")
+    # MoE-specific param counts shipped on the morning's qwen3-coder-30b-a3b
+    # and OLMoE flagships (forgedParamsB after expert pruning, activeParamsB
+    # is unchanged because expert pruning doesn't change activation count).
+    forged_params_b: Optional[float] = Field(default=None, alias="forgedParamsB")
+    active_params_b: Optional[float] = Field(default=None, alias="activeParamsB")
     benchmarks: list[BenchmarkResult] = Field(default_factory=list)
     hardware_verified: list[HardwareProfile] = Field(default_factory=list, alias="hardwareVerified")
     samples: list[GenerationSample] = Field(default_factory=list)
     integrity: Optional[IntegrityAttestation] = None
 
-    model_config = {"populate_by_name": True}
+    # extra="allow" so artifact-specific result extras (fourRunProgression,
+    # lossFunctionAblation, etc. on v2-7b-coder-compensated) round-trip
+    # cleanly. The schema's named fields are the canonical surface; extras
+    # are recognized as artifact-specific provenance and preserved verbatim.
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 # ── Stages ──────────────────────────────────────────────────────────────────
@@ -204,7 +245,7 @@ class TrainStage(BaseModel):
     sequence_length: int = Field(default=2048, ge=128, le=131072, alias="sequenceLength")
     optimizations: list[str] = Field(default_factory=list)
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class LoRAStage(BaseModel):
@@ -221,7 +262,7 @@ class LoRAStage(BaseModel):
     batch_size: int = Field(default=4, ge=1, le=64, alias="batchSize")
     merge_after: bool = Field(default=False, alias="mergeAfter")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class CompactStage(BaseModel):
@@ -234,7 +275,7 @@ class CompactStage(BaseModel):
     target_size_gb: Optional[float] = Field(default=None, alias="targetSizeGb")
     enable_quantization: bool = Field(default=True, alias="enableQuantization")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class QuantStage(BaseModel):
@@ -243,7 +284,7 @@ class QuantStage(BaseModel):
     quant_types: list[str] = Field(alias="quantTypes")
     device_targets: list[str] = Field(default_factory=list, alias="deviceTargets")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class BenchmarkDef(BaseModel):
@@ -280,7 +321,7 @@ class PublishStage(BaseModel):
     private: bool = False
     card_hash: Optional[str] = Field(default=None, alias="cardHash")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class ExpertActivationProfileStage(BaseModel):
@@ -358,7 +399,7 @@ class ContextExtendStage(BaseModel):
     training_dataset: Optional[str] = Field(default=None, alias="trainingDataset")
     training_steps: Optional[int] = Field(default=None, alias="trainingSteps")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class ModalityStage(BaseModel):
@@ -372,7 +413,7 @@ class ModalityStage(BaseModel):
     training_steps: Optional[int] = Field(default=None, alias="trainingSteps")
     projection_dim: Optional[int] = Field(default=None, alias="projectionDim")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class AlloyHardware(BaseModel):
@@ -381,8 +422,13 @@ class AlloyHardware(BaseModel):
     estimated_duration_minutes: Optional[float] = Field(default=None, alias="estimatedDurationMinutes")
     supports_cpu: bool = Field(default=False, alias="supportsCPU")
     tested_on: list[str] = Field(default_factory=list, alias="testedOn")
+    # Device target list — every published continuum-ai/* alloy carries this
+    # field at hardware.deviceTargets. Caught by the regression round-trip
+    # test 2026-04-08: pydantic was silently dropping it because the schema
+    # didn't have it.
+    device_targets: list[str] = Field(default_factory=list, alias="deviceTargets")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 # ── Bookend stage types ───────────────────────────────────────────────────── ───────────────────────────────────────────────
@@ -397,7 +443,7 @@ class SourceConfigStage(BaseModel):
     target_batch_size: Optional[int] = Field(default=None, alias="targetBatchSize")
     target_devices: list[str] = Field(default_factory=list, alias="targetDevices")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class PackageStage(BaseModel):
@@ -409,7 +455,7 @@ class PackageStage(BaseModel):
     validate_on: list[str] = Field(default_factory=list, alias="validateOn")
     include_tokenizer: bool = Field(default=True, alias="includeTokenizer")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class DeployStage(BaseModel):
@@ -421,7 +467,7 @@ class DeployStage(BaseModel):
     max_concurrency: Optional[int] = Field(default=None, alias="maxConcurrency")
     auto_scale: Optional[bool] = Field(default=None, alias="autoScale")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 # Discriminated union for stages — must be after ALL stage class definitions
@@ -453,7 +499,7 @@ class AlloyTarget(BaseModel):
     benchmarks: Optional[list[str]] = None
     publish: Optional[bool] = None
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 # ── Receipt (proof of delivery) ─────────────────────────────────────────────
@@ -466,7 +512,7 @@ class Publication(BaseModel):
     published_at: str = Field(alias="publishedAt")
     downloads: Optional[int] = None
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class AlloyReceipt(BaseModel):
@@ -477,7 +523,7 @@ class AlloyReceipt(BaseModel):
     card_hash: Optional[str] = Field(default=None, alias="cardHash")
     issued_at: str = Field(alias="issuedAt")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 # ── Hardware & Outputs ──────────────────────────────────────────────────────

--- a/python/forge_alloy/types.py
+++ b/python/forge_alloy/types.py
@@ -231,10 +231,14 @@ class PruneStage(BaseModel):
 
 class TrainStage(BaseModel):
     type: Literal["train"] = "train"
-    domain: str
+    # domain / steps / learning_rate are OPTIONAL — when omitted, the
+    # family adapter's default_train_params() hook fills them in at
+    # execution time. Recipe authors only need to specify these when
+    # they want to override the family-default. Adapter-driven > seeder-hardcoded.
+    domain: Optional[str] = None
     dataset: Optional[str] = None
-    steps: int = Field(ge=1)
-    learning_rate: str = Field(alias="learningRate")
+    steps: Optional[int] = Field(default=None, ge=1)
+    learning_rate: Optional[str] = Field(default=None, alias="learningRate")
     batch_size: int = Field(default=4, ge=1, le=64, alias="batchSize")
     gradient_accumulation: int = Field(default=1, ge=1, le=16, alias="gradientAccumulation")
     scheduler: Literal["cosine", "linear", "constant", "constant_with_warmup", "polynomial"] = "cosine"

--- a/python/forge_alloy/types.py
+++ b/python/forge_alloy/types.py
@@ -416,6 +416,54 @@ class ModalityStage(BaseModel):
     model_config = {"populate_by_name": True, "extra": "allow"}
 
 
+class BenchmarkAcceptance(BaseModel):
+    """Acceptance criterion for one benchmark.
+
+    `min` is the absolute pass@1 floor (0..1) the forged model must clear.
+    `anchorDelta` is the §4.1.3.4 discipline gate: the forged score must
+    be within Δ of the base anchor measured in the SAME eval pipeline.
+    Negative means forged ≥ anchor + delta (i.e. anchorDelta=-3 means the
+    forged score is allowed to drop by at most 3 percentage points
+    relative to the unmodified base anchor).
+    """
+    min: float = Field(..., ge=0.0, le=1.0)
+    anchor_delta: Optional[float] = Field(default=None, alias="anchorDelta")
+    anchor_benchmark: Optional[str] = Field(default=None, alias="anchorBenchmark")
+    notes: Optional[str] = None
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class AcceptanceHardware(BaseModel):
+    """Hardware acceptance criteria — must fit on the declared tier."""
+    max_vram_gb: Optional[float] = Field(default=None, alias="maxVramGb")
+    device_tier: Optional[str] = Field(default=None, alias="deviceTier")
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class AcceptanceIntegrity(BaseModel):
+    """Integrity acceptance criteria — chain-of-custody requirements."""
+    model_hash_required: bool = Field(default=False, alias="modelHashRequired")
+    samples_path_required: bool = Field(default=False, alias="samplesPathRequired")
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class AcceptanceCriteria(BaseModel):
+    """The part spec — gate the forged model must clear before shipping.
+
+    Lives on the alloy itself (the alloy IS the part spec). Sentinel-ai
+    forges and assays; it never reads acceptanceCriteria. Continuum (the
+    shipping department) reads BOTH the assayed scores written into the
+    finished/ manifest AND the alloy's acceptanceCriteria, and decides
+    ship vs rework. Same alloy → same gate verdict on any forge run by
+    anyone, anywhere — the spec is portable.
+    """
+    benchmarks: dict[str, BenchmarkAcceptance] = Field(default_factory=dict)
+    hardware: Optional[AcceptanceHardware] = None
+    integrity: Optional[AcceptanceIntegrity] = None
+    notes: Optional[str] = None
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
 class AlloyHardware(BaseModel):
     min_vram_gb: Optional[float] = Field(default=None, alias="minVramGb")
     recommended_vram_gb: Optional[float] = Field(default=None, alias="recommendedVramGb")
@@ -597,6 +645,11 @@ class ForgeAlloy(BaseModel):
     methodology_paper_url: Optional[str] = Field(default=None, alias="methodologyPaperUrl")
     calibration_corpora: list[CalibrationCorpusRef] = Field(default_factory=list, alias="calibrationCorpora")
     prior_metric_baselines: list[PriorMetricBaseline] = Field(default_factory=list, alias="priorMetricBaselines")
+
+    # The part spec — gate the forged model must clear before continuum
+    # ships it. Optional (backwards compat with every existing alloy).
+    # Sentinel never reads this; continuum's shipping flow does.
+    acceptance_criteria: Optional[AcceptanceCriteria] = Field(default=None, alias="acceptanceCriteria")
 
     model_config = {"populate_by_name": True, "extra": "allow"}
 

--- a/python/forge_alloy/types.py
+++ b/python/forge_alloy/types.py
@@ -35,7 +35,8 @@ class BenchmarkResult(BaseModel):
 class HardwareProfile(BaseModel):
     """Verified performance on a specific device — generates model card device grid."""
     device: str
-    format: str
+    format: Optional[str] = None
+    vram_gb: Optional[float] = Field(default=None, alias="vramGb")
     size_gb: Optional[float] = Field(default=None, alias="sizeGb")
     tokens_per_sec: Optional[float] = Field(default=None, alias="tokensPerSec")
     memory_usage_gb: Optional[float] = Field(default=None, alias="memoryUsageGb")
@@ -96,8 +97,8 @@ class IntegrityAttestation(BaseModel):
     Self-attested only prevents accidental corruption, NOT adversarial modification.
     Only enclave tier provides tamper-proof guarantees."""
     trust_level: Literal["self-attested", "verified", "enclave"] = Field(default="self-attested", alias="trustLevel")
-    code: CodeAttestation
-    model_hash: str = Field(alias="modelHash")
+    code: Optional[CodeAttestation] = None
+    model_hash: Optional[str] = Field(default=None, alias="modelHash")
     alloy_hash: Optional[str] = Field(default=None, alias="alloyHash")
     datasets: list[DatasetAttestation] = Field(default_factory=list)
     nonce: Optional[str] = None
@@ -105,9 +106,9 @@ class IntegrityAttestation(BaseModel):
     signature: Optional[AttestationSignature] = None
     anchor: Optional["TrustAnchor"] = None
     certifications: list["AdapterAttestation"] = Field(default_factory=list)
-    attested_at: str = Field(alias="attestedAt")
+    attested_at: Optional[str] = Field(default=None, alias="attestedAt")
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class AdapterAttestation(BaseModel):
@@ -163,13 +164,28 @@ class AlloyResults(BaseModel):
 
 class PruneStage(BaseModel):
     type: Literal["prune"] = "prune"
-    strategy: Literal["entropy", "magnitude", "gradient", "random"]
+    # Strategy enum extended with activation-magnitude (the §4.1.3.1 fix metric
+    # used by the v2-7B forge published as continuum-ai/qwen2.5-coder-7b-compacted)
+    # and per-layer-normalized-* variants surfaced by the §4.1.3.4 work.
+    strategy: Literal[
+        "entropy",
+        "magnitude",
+        "gradient",
+        "random",
+        "activation-magnitude",
+        "calibration-aware-activation-count",
+        "per-layer-normalized-router-importance",
+    ]
     level: float = Field(ge=0.0, le=0.9)
     min_heads_per_layer: int = Field(default=4, alias="minHeadsPerLayer")
     min_kv_heads_per_layer: int = Field(default=2, alias="minKvHeadsPerLayer")
     analysis_steps: int = Field(default=200, alias="analysisSteps")
+    # Optional methodology metadata fields used by post-§4.1.3 forges
+    per_layer_normalized: Optional[bool] = Field(default=None, alias="perLayerNormalized")
+    defrag_mode: Optional[str] = Field(default=None, alias="defragMode")
+    notes: Optional[str] = None
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class TrainStage(BaseModel):
@@ -235,8 +251,12 @@ class BenchmarkDef(BaseModel):
     subset: Optional[str] = None
     n_shot: Optional[int] = Field(default=None, alias="nShot")
     submit_to_leaderboard: bool = Field(default=False, alias="submitToLeaderboard")
+    samples_path: Optional[str] = Field(default=None, alias="samplesPath")
+    base_samples_path: Optional[str] = Field(default=None, alias="baseSamplesPath")
+    calibration_anchor: Optional[dict[str, Any]] = Field(default=None, alias="calibrationAnchor")
+    notes: Optional[str] = None
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class EvalStage(BaseModel):
@@ -244,8 +264,10 @@ class EvalStage(BaseModel):
     benchmarks: list[BenchmarkDef]
     passing_threshold: Optional[float] = Field(default=None, alias="passingThreshold")
     compare_to_base: bool = Field(default=True, alias="compareToBase")
+    calibration_anchor: Optional[dict[str, Any]] = Field(default=None, alias="calibrationAnchor")
+    notes: Optional[str] = None
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class PublishStage(BaseModel):
@@ -261,14 +283,72 @@ class PublishStage(BaseModel):
     model_config = {"populate_by_name": True}
 
 
+class ExpertActivationProfileStage(BaseModel):
+    """§4.1.3.4 calibration-aware MoE expert importance profiling.
+    Produces an importance JSON consumed by a downstream expert-prune stage."""
+    type: Literal["expert-activation-profile"] = "expert-activation-profile"
+    calibration_corpus: str = Field(alias="calibrationCorpus")
+    metric: Literal["activation_count", "router_l2", "activation_magnitude"] = "activation_count"
+    max_length: int = Field(default=2048, ge=128, alias="maxLength")
+    device: Optional[str] = None
+    importance_output: Optional[str] = Field(default=None, alias="importanceOutput")
+    notes: Optional[str] = None
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class CompensationLoRAStage(BaseModel):
+    """§4.1.3.3 KL-distillation-against-teacher compensation LoRA."""
+    type: Literal["compensation-lora"] = "compensation-lora"
+    teacher: str
+    calibration_corpus: str = Field(alias="calibrationCorpus")
+    loss_type: Literal["kl_logits", "mse_hidden", "both"] = Field(default="kl_logits", alias="lossType")
+    kd_temperature: float = Field(default=2.0, ge=0.0, alias="kdTemperature")
+    lora_rank: int = Field(default=16, ge=1, alias="loraRank")
+    lora_alpha: int = Field(default=32, ge=1, alias="loraAlpha")
+    target_modules: list[str] = Field(default_factory=list, alias="targetModules")
+    steps: int = Field(default=500, ge=1)
+    learning_rate: str = Field(default="1e-4", alias="learningRate")
+    teacher_quant: Optional[Literal["8bit", "4bit", "fp16"]] = Field(default=None, alias="teacherQuant")
+    student_quant: Optional[Literal["fp16", "4bit", "8bit"]] = Field(default=None, alias="studentQuant")
+    merged_at_save: bool = Field(default=True, alias="mergedAtSave")
+    notes: Optional[str] = None
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
 class ExpertPruneStage(BaseModel):
     type: Literal["expert-prune"] = "expert-prune"
-    keep_experts: int = Field(ge=1, alias="keepExperts")
-    selection_strategy: Literal["activation", "gradient", "random"] = Field(default="activation", alias="selectionStrategy")
+    # Either flat keep_experts (legacy) OR keep_experts_per_layer (post-§4.1.3.4)
+    keep_experts: Optional[int] = Field(default=None, ge=1, alias="keepExperts")
+    keep_experts_per_layer: Optional[int] = Field(default=None, ge=1, alias="keepExpertsPerLayer")
+    original_experts_per_layer: Optional[int] = Field(default=None, alias="originalExpertsPerLayer")
+    # Strategy/selection — both forms shipped on published alloys
+    strategy: Optional[str] = None
+    selection_strategy: Optional[str] = Field(default=None, alias="selectionStrategy")
+    metric: Optional[str] = None
+    metric_source: Optional[str] = Field(default=None, alias="metricSource")
     profile_dataset: Optional[str] = Field(default=None, alias="profileDataset")
     profile_steps: int = Field(default=100, ge=1, alias="profileSteps")
+    importance_json: Optional[str] = Field(default=None, alias="importanceJson")
+    expert_tensor_layout: Optional[Literal[
+        "auto",
+        "mlp-experts-unfused",
+        "block_sparse_moe-unfused",
+        "granite-moe-fused",
+        "deepseek-routed-shared",
+    ]] = Field(default="auto", alias="expertTensorLayout")
+    calibration_corpus: Optional[str] = Field(default=None, alias="calibrationCorpus")
+    per_layer_normalized: Optional[bool] = Field(default=None, alias="perLayerNormalized")
+    prune_pct: Optional[float] = Field(default=None, alias="prunePct")
+    experts_dropped: Optional[int] = Field(default=None, alias="expertsDropped")
+    experts_renamed: Optional[int] = Field(default=None, alias="expertsRenamed")
+    router_sliced_layers: Optional[int] = Field(default=None, alias="routerSlicedLayers")
+    implementation: Optional[str] = None
+    rationale: Optional[str] = None
+    notes: Optional[str] = None
 
-    model_config = {"populate_by_name": True}
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class ContextExtendStage(BaseModel):
@@ -349,7 +429,8 @@ AlloyStage = Annotated[
     Union[
         SourceConfigStage, PruneStage, TrainStage, LoRAStage, CompactStage,
         QuantStage, PackageStage, EvalStage, PublishStage, DeployStage,
-        ExpertPruneStage, ContextExtendStage, ModalityStage,
+        ExpertPruneStage, ExpertActivationProfileStage, CompensationLoRAStage,
+        ContextExtendStage, ModalityStage,
     ],
     Field(discriminator="type"),
 ]
@@ -411,10 +492,42 @@ class AlloyOutputs(BaseModel):
     produces: list[OutputArtifact] = Field(default_factory=list)
 
 
+class CalibrationCorpusRef(BaseModel):
+    """§4.1.3.4.1 calibration corpus discipline gate — declared at alloy root."""
+    id: str
+    name: Optional[str] = None
+    path: str
+    sha256: Optional[str] = None
+    examples: Optional[int] = None
+    tokens: Optional[int] = None
+    distribution_summary: Optional[str] = Field(default=None, alias="distributionSummary")
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class PriorMetricBaseline(BaseModel):
+    """§4.1.3.4 negative-baseline empirical control. Preserves superseded
+    forge attempts as falsifiability anchors in the published artifact."""
+    id: Optional[str] = None
+    name: Optional[str] = None
+    metric: Optional[Union[str, dict[str, Any]]] = None
+    evaluation: Optional[dict[str, Any]] = None
+    prune: Optional[dict[str, Any]] = None
+    results: Optional[dict[str, Any]] = None
+    samples_path: Optional[str] = Field(default=None, alias="samplesPath")
+    outcome: Optional[Literal["shipped", "negative_baseline", "superseded"]] = None
+    superseded_by: Optional[str] = Field(default=None, alias="supersededBy")
+    methodology_anchor: Optional[str] = Field(default=None, alias="methodologyAnchor")
+    notes: Optional[str] = None
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
 class ForgeAlloy(BaseModel):
     name: str
     version: str
     description: str = ""
+    user_summary: Optional[str] = Field(default=None, alias="userSummary")
     author: str = ""
     tags: list[str] = Field(default_factory=list)
     license: str = "apache-2.0"
@@ -433,7 +546,13 @@ class ForgeAlloy(BaseModel):
     source_alloy_id: Optional[str] = Field(default=None, alias="sourceAlloyId")
     forged_model_ids: Optional[list[str]] = Field(default=None, alias="forgedModelIds")
 
-    model_config = {"populate_by_name": True}
+    # Methodology / prose fields shipped on continuum-ai/* artifacts
+    limitations: list[str] = Field(default_factory=list)
+    methodology_paper_url: Optional[str] = Field(default=None, alias="methodologyPaperUrl")
+    calibration_corpora: list[CalibrationCorpusRef] = Field(default_factory=list, alias="calibrationCorpora")
+    prior_metric_baselines: list[PriorMetricBaseline] = Field(default_factory=list, alias="priorMetricBaselines")
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
     @classmethod
     def from_file(cls, path: str | Path) -> "ForgeAlloy":

--- a/python/tests/test_acceptance_criteria.py
+++ b/python/tests/test_acceptance_criteria.py
@@ -1,0 +1,172 @@
+"""TDD spec for ForgeAlloy.acceptanceCriteria — the part spec.
+
+In the assembly-line metaphor every part has a spec sheet that travels
+with it down the line. The alloy IS the part spec — it carries the
+recipe (stages), the source, the integrity attestation, AND the gate
+the part must clear before the shipping department releases it.
+
+`acceptanceCriteria` is that gate, declared by the recipe author and
+self-contained in the alloy file. Sentinel-ai forges and assays; it
+NEVER reads acceptanceCriteria. Continuum (the shipping department)
+reads BOTH the assayed scores and the alloy's acceptanceCriteria, and
+decides ship vs rework. The same alloy gives the same gate verdict on
+any forge run by anyone, anywhere — that's the portability the spec
+guarantees.
+
+Schema:
+    acceptanceCriteria: {
+        benchmarks: {
+            <benchmark_name>: { min: float, anchorDelta?: float, anchorBenchmark?: str }
+        },
+        hardware?: { maxVramGb?: float, deviceTier?: str },
+        integrity?: { modelHashRequired?: bool, samplesPathRequired?: bool }
+    }
+
+  benchmarks.<name>.min            — absolute pass@1 floor (0..1)
+  benchmarks.<name>.anchorDelta    — §4.1.3.4 discipline gate: the
+                                     forged score must be within Δ of
+                                     the base anchor measured in the
+                                     SAME eval pipeline. Negative means
+                                     forged ≥ anchor + delta (i.e. -3
+                                     means forged must be ≥ anchor−3).
+  hardware.maxVramGb               — must fit in this VRAM after quant
+  integrity.modelHashRequired      — modelHash must be present + valid
+
+Tests:
+  1. AcceptanceCriteria class importable from forge_alloy
+  2. ForgeAlloy.acceptanceCriteria field exists, defaults to None
+  3. Round-trip via model_dump_json + from_file preserves the field
+  4. Pydantic validates min as 0..1 float
+  5. Pydantic validates each benchmark entry is a BenchmarkAcceptance
+  6. Backwards compat: existing alloys without acceptanceCriteria load
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _minimal_alloy_dict() -> dict:
+    return {
+        "name": "test-alloy",
+        "version": "0.1.0",
+        "source": {"baseModel": "Test/Base", "architecture": "qwen3_moe"},
+        "stages": [
+            {"type": "prune", "level": 0.3, "strategy": "entropy"},
+        ],
+    }
+
+
+# ── AcceptanceCriteria class importable ─────────────────────────────────────
+
+
+def test_acceptance_criteria_class_importable():
+    from forge_alloy.types import AcceptanceCriteria, BenchmarkAcceptance
+    assert AcceptanceCriteria is not None
+    assert BenchmarkAcceptance is not None
+
+
+def test_benchmark_acceptance_validates_min_as_fraction():
+    from forge_alloy.types import BenchmarkAcceptance
+    ok = BenchmarkAcceptance(min=0.55)
+    assert ok.min == 0.55
+    # Optional anchorDelta
+    with_delta = BenchmarkAcceptance(min=0.78, anchorDelta=-3.0, anchorBenchmark="humaneval_plus")
+    assert with_delta.anchor_delta == -3.0
+    assert with_delta.anchor_benchmark == "humaneval_plus"
+
+
+def test_benchmark_acceptance_rejects_out_of_range_min():
+    from forge_alloy.types import BenchmarkAcceptance
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        BenchmarkAcceptance(min=1.5)
+    with pytest.raises(ValidationError):
+        BenchmarkAcceptance(min=-0.1)
+
+
+# ── ForgeAlloy.acceptanceCriteria field ─────────────────────────────────────
+
+
+def test_forge_alloy_has_acceptance_criteria_field():
+    from forge_alloy.types import ForgeAlloy
+    alloy = ForgeAlloy.model_validate(_minimal_alloy_dict())
+    # Default is None — the field is optional, backwards compat
+    assert alloy.acceptance_criteria is None
+
+
+def test_forge_alloy_accepts_acceptance_criteria_in_payload():
+    from forge_alloy.types import ForgeAlloy
+    payload = _minimal_alloy_dict()
+    payload["acceptanceCriteria"] = {
+        "benchmarks": {
+            "humaneval_plus": {"min": 0.78, "anchorDelta": -3.0, "anchorBenchmark": "humaneval_plus"},
+            "ifeval": {"min": 0.55},
+            "mmlu_pro": {"min": 0.42},
+        },
+        "hardware": {"maxVramGb": 24.0},
+        "integrity": {"modelHashRequired": True},
+    }
+    alloy = ForgeAlloy.model_validate(payload)
+    assert alloy.acceptance_criteria is not None
+    bench = alloy.acceptance_criteria.benchmarks
+    assert bench["humaneval_plus"].min == 0.78
+    assert bench["humaneval_plus"].anchor_delta == -3.0
+    assert bench["ifeval"].min == 0.55
+    assert alloy.acceptance_criteria.hardware.max_vram_gb == 24.0
+    assert alloy.acceptance_criteria.integrity.model_hash_required is True
+
+
+def test_forge_alloy_round_trip_preserves_acceptance_criteria(tmp_path):
+    from forge_alloy.types import ForgeAlloy
+    payload = _minimal_alloy_dict()
+    payload["acceptanceCriteria"] = {
+        "benchmarks": {
+            "ifeval": {"min": 0.55},
+            "mmlu_pro": {"min": 0.42},
+        },
+        "hardware": {"maxVramGb": 24.0},
+    }
+    alloy = ForgeAlloy.model_validate(payload)
+
+    out = tmp_path / "rt.alloy.json"
+    alloy.to_file(out)
+    text = out.read_text()
+    # The serialized JSON MUST use the camelCase alias the spec ships under
+    assert "acceptanceCriteria" in text
+    assert "maxVramGb" in text
+
+    reloaded = ForgeAlloy.from_file(out)
+    assert reloaded.acceptance_criteria is not None
+    assert reloaded.acceptance_criteria.benchmarks["ifeval"].min == 0.55
+    assert reloaded.acceptance_criteria.benchmarks["mmlu_pro"].min == 0.42
+    assert reloaded.acceptance_criteria.hardware.max_vram_gb == 24.0
+
+
+def test_forge_alloy_backwards_compat_alloys_without_criteria_load():
+    """Every existing published continuum-ai/* alloy must keep loading
+    after this field is added — it's optional with default None."""
+    from forge_alloy.types import ForgeAlloy
+    alloy = ForgeAlloy.model_validate(_minimal_alloy_dict())
+    assert alloy.acceptance_criteria is None
+    # And serializes cleanly without the field
+    text = alloy.model_dump_json(by_alias=True, exclude_none=True)
+    assert "acceptanceCriteria" not in text
+
+
+# ── The §4.1.3.4 anchor delta semantic check ────────────────────────────────
+
+
+def test_anchor_delta_carries_negative_threshold_for_4_1_3_4_gate():
+    """anchorDelta = -3.0 means 'forged score must be within 3 points
+    BELOW the base anchor measured in the same eval pipeline'. Negative
+    is the correct sign convention because the forged score is allowed
+    to drop slightly relative to the base — the §4.1.3.4 discipline is
+    'how much drop is OK', not 'how much must we exceed'."""
+    from forge_alloy.types import BenchmarkAcceptance
+    crit = BenchmarkAcceptance(min=0.78, anchorDelta=-3.0, anchorBenchmark="humaneval_plus")
+    assert crit.anchor_delta == -3.0
+    assert crit.anchor_delta < 0

--- a/python/tests/test_domain_extension_layout.py
+++ b/python/tests/test_domain_extension_layout.py
@@ -1,0 +1,262 @@
+"""TDD spec for the forge_alloy domain-extension package layout.
+
+Roadmap step 5 from sentinel-ai/docs/PLUGIN-SPRINT.md and the schema-side
+proposal in continuum/docs/architecture/FORGE-ALLOY-DOMAIN-EXTENSIBILITY.md:
+move every ML-specific stage type and root extension out of the universal
+forge_alloy.types core and into a forge_alloy.domains.llm_forge extension.
+The universal core stays domain-agnostic (suitable for photo provenance,
+ticketing, delivery, compute receipts — any data transformation pipeline,
+not just ML model forging).
+
+Written test-first per TDD/TDValidation discipline. The contract this
+test asserts IS the spec the refactor must satisfy. The bd4349d
+checkpoint commit on this branch is the wrong-layered first attempt
+(ML fields bolted into the universal core); the wip preservation branch
+wip/types-additive-checkpoint-bd4349d holds it for the never-lose-work rule.
+
+This test runs offline against the existing forge_alloy package — no
+network, no model loading, no external services.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "python"))
+
+
+# ── domains/ package exists ─────────────────────────────────────────────────
+
+
+def test_domains_package_is_importable():
+    """forge_alloy.domains MUST be a package (directory with __init__.py).
+
+    The mechanism for registering and resolving domain extensions lives
+    here. Each ML / non-ML use case gets its own module under this
+    package and registers via the package-level registry.
+    """
+    pkg = importlib.import_module("forge_alloy.domains")
+    assert pkg is not None
+    assert hasattr(pkg, "__path__"), "forge_alloy.domains must be a package, not a module"
+
+
+def test_domain_registry_is_importable():
+    """The DomainRegistry singleton + its helpers MUST be importable."""
+    from forge_alloy.domains import (
+        DomainRegistry,
+        register_domain,
+        resolve_domain,
+        registered_domains,
+    )
+    assert DomainRegistry is not None
+    assert callable(register_domain)
+    assert callable(resolve_domain)
+    assert callable(registered_domains)
+
+
+def test_domain_extension_base_class_exists():
+    """The DomainExtension ABC defines the contract every registered
+    domain must satisfy. At minimum it carries an `id` (the string the
+    alloy's domains[] field carries) and a method to enumerate the
+    stage types this domain owns."""
+    from forge_alloy.domains.base import DomainExtension
+    assert hasattr(DomainExtension, "id")
+    assert hasattr(DomainExtension, "stage_types")
+
+
+# ── llm_forge domain extension ──────────────────────────────────────────────
+
+
+def test_llm_forge_domain_module_is_importable():
+    """forge_alloy.domains.llm_forge MUST be importable. This module owns
+    every ML-specific stage type and root extension (the things that used
+    to be bolted into types.py via the bd4349d checkpoint)."""
+    mod = importlib.import_module("forge_alloy.domains.llm_forge")
+    assert mod is not None
+
+
+def test_llm_forge_is_registered():
+    """The llm-forge domain MUST be registered against the singleton on
+    package import. resolve_domain('llm-forge') returns the extension."""
+    from forge_alloy.domains import resolve_domain
+    ext = resolve_domain("llm-forge")
+    assert ext is not None
+    assert ext.id == "llm-forge"
+
+
+def test_llm_forge_owns_the_ml_stage_types():
+    """Every ML stage type MUST be owned by the llm_forge domain extension.
+    These are the stage types the morning's flagship qwen3-coder-30b-a3b
+    alloy uses + the stage types the rest of the published catalog uses."""
+    from forge_alloy.domains import resolve_domain
+    ext = resolve_domain("llm-forge")
+    owned = set(ext.stage_types().keys())
+    # The morning's MoE flagship uses these stage types
+    expected = {
+        "prune",
+        "train",
+        "lora",
+        "expert-prune",
+        "expert-activation-profile",
+        "compensation-lora",
+        "context-extend",
+        "modality",
+        "quant",
+        "eval",
+        "publish",
+        "package",
+        "deploy",
+        "deliver",
+        "source-config",
+    }
+    missing = expected - owned
+    assert not missing, (
+        f"llm-forge domain extension is missing stage types: {sorted(missing)}. "
+        f"Owned: {sorted(owned)}"
+    )
+
+
+def test_llm_forge_exposes_priormetricbaseline():
+    """The §4.1.3.4 falsifiability anchor structure (PriorMetricBaseline)
+    is an ML-specific concept and MUST live in the llm_forge domain
+    extension, NOT in the universal core."""
+    from forge_alloy.domains.llm_forge import PriorMetricBaseline
+    assert PriorMetricBaseline is not None
+
+
+def test_llm_forge_exposes_calibration_corpus_ref():
+    """Calibration corpus reference is the §4.1.3.4.1 discipline gate
+    structure. ML-specific. Must live in the llm_forge extension."""
+    from forge_alloy.domains.llm_forge import CalibrationCorpusRef
+    assert CalibrationCorpusRef is not None
+
+
+def test_llm_forge_exposes_expert_prune_stage():
+    """Expert pruning is the §4.1.3.4 mechanism. Must live in llm_forge."""
+    from forge_alloy.domains.llm_forge import ExpertPruneStage
+    assert ExpertPruneStage is not None
+
+
+# ── Stub domain extensions to prove the mechanism is non-ML ─────────────────
+
+
+def test_photo_provenance_stub_is_importable():
+    """forge_alloy.domains.photo_provenance MUST be importable as a stub
+    that proves the registry mechanism handles non-ML domains. The actual
+    schema is empty for now — the point is that adding a non-ML domain
+    is one new file, no edits to the universal core."""
+    mod = importlib.import_module("forge_alloy.domains.photo_provenance")
+    assert mod is not None
+
+
+def test_photo_provenance_is_registered():
+    from forge_alloy.domains import resolve_domain
+    ext = resolve_domain("photo-provenance")
+    assert ext is not None
+    assert ext.id == "photo-provenance"
+
+
+def test_ticketing_stub_is_importable():
+    """Same proof for the ticketing domain — non-ML, registered, separate
+    file. Adding a new domain is never a core edit."""
+    mod = importlib.import_module("forge_alloy.domains.ticketing")
+    assert mod is not None
+
+
+def test_ticketing_is_registered():
+    from forge_alloy.domains import resolve_domain
+    ext = resolve_domain("ticketing")
+    assert ext is not None
+    assert ext.id == "ticketing"
+
+
+def test_registered_domains_lists_all_three():
+    """The singleton MUST know about all three domains after package import:
+    llm-forge (the real one), photo-provenance + ticketing (the stubs).
+    Adding a new domain is one new file plus one import in
+    forge_alloy/domains/__init__.py."""
+    from forge_alloy.domains import registered_domains
+    domains = set(registered_domains())
+    expected = {"llm-forge", "photo-provenance", "ticketing"}
+    missing = expected - domains
+    assert not missing, (
+        f"registered_domains() missing: {sorted(missing)}. "
+        f"Got: {sorted(domains)}"
+    )
+
+
+# ── Registry behavior contract ──────────────────────────────────────────────
+
+
+def test_resolve_unknown_domain_raises_clearly():
+    """Unknown domain id MUST raise with a message naming what IS
+    registered. Loud failure, no silent default to llm-forge."""
+    from forge_alloy.domains import resolve_domain
+    with pytest.raises((KeyError, ValueError)) as exc_info:
+        resolve_domain("not-a-real-domain")
+    msg = str(exc_info.value)
+    assert "not-a-real-domain" in msg
+    assert "llm-forge" in msg, "error must list registered domains"
+
+
+def test_register_different_class_against_same_id_raises():
+    """Re-registering a DIFFERENT extension class against an existing id
+    MUST raise. Silent shadowing is the f-word pattern — one domain
+    extension shadowing another would silently change the schema for
+    every alloy that declares that domain."""
+    from forge_alloy.domains import DomainRegistry
+    from forge_alloy.domains.base import DomainExtension
+
+    class FirstExt(DomainExtension):
+        id = "shared-id"
+        def stage_types(self):
+            return {}
+        def root_extensions(self):
+            return {}
+
+    class SecondExt(DomainExtension):
+        id = "shared-id"
+        def stage_types(self):
+            return {}
+        def root_extensions(self):
+            return {}
+
+    reg = DomainRegistry()
+    reg.register(FirstExt)
+    reg.register(FirstExt)  # idempotent same class
+    with pytest.raises(ValueError) as exc_info:
+        reg.register(SecondExt)
+    assert "shared-id" in str(exc_info.value)
+
+
+# ── Universal core hygiene ──────────────────────────────────────────────────
+
+
+def test_universal_core_does_not_import_llm_forge():
+    """forge_alloy.types (the universal core) MUST NOT import anything
+    from the llm_forge domain extension. The dependency direction is
+    extensions → core, never core → extensions. Otherwise the universal
+    core becomes ML-locked again, defeating the purpose of the domain
+    package.
+
+    This test parses types.py source and checks for any import of
+    forge_alloy.domains.* — would catch a refactor that accidentally
+    introduces a back-import.
+    """
+    types_src = (REPO_ROOT / "python" / "forge_alloy" / "types.py").read_text()
+    forbidden_imports = [
+        "from forge_alloy.domains",
+        "from .domains",
+        "import forge_alloy.domains",
+    ]
+    for forbidden in forbidden_imports:
+        assert forbidden not in types_src, (
+            f"forge_alloy/types.py contains forbidden import {forbidden!r}. "
+            f"The universal core must not depend on any domain extension; "
+            f"the dependency direction is extensions → core, never core → extensions."
+        )

--- a/python/tests/test_regression_published_alloys.py
+++ b/python/tests/test_regression_published_alloys.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Regression test: every published continuum-ai/* alloy must round-trip
+through the forge-alloy schema with semantic equivalence (no information
+loss). This is the §4.1.3.4 reproducibility gate from
+docs/architecture/FORGE-ALLOY-DOMAIN-EXTENSIBILITY.md in continuum.
+
+Run before merging any forge-alloy schema change. Fails the merge if any
+shipped artifact's alloy does not round-trip cleanly through the
+post-change schema.
+
+Usage:
+    python tests/test_regression_published_alloys.py
+
+The test downloads each published alloy directly from HuggingFace (no
+local copies) so it always tests against the actual immutable shipped
+content, not a stale local cache.
+"""
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# Make `forge_alloy` importable when this file is run via pytest from the
+# repo root or directly as a script. The package lives under python/.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "python"))
+
+# Tracked published alloys. Add new shipped artifacts here.
+PUBLISHED_ALLOYS = [
+    {
+        "repo": "continuum-ai/qwen3-coder-30b-a3b-compacted-19b-256k",
+        "filename": "qwen3-coder-30b-a3b-compacted-19b-256k.alloy.json",
+        # Note: hash updated 2026-04-08 from aa61c4bdf463847c → 011970c80c2f3429
+        # after the canonical-evalplus humaneval_plus correction landed
+        # (sentinel-ai commit 1bc32d2). Tier 4 reproducibility test caught the
+        # 0.6pp non-canonical convention bug; the alloy was re-published via
+        # republish_alloy_only.py with corrected scores.
+        "expected_alloy_hash_prefix": "011970c80c2f3429",
+        "ad_hoc_fields": [
+            "expert-activation-profile",  # stage type
+            "expert-prune",                # stage type
+            "calibrationCorpora",          # root extension (NOT YET in schema)
+            "priorMetricBaselines",        # root extension (NOT YET in schema)
+        ],
+    },
+    {
+        "repo": "continuum-ai/olmoe-1b-7b-compacted-5b",
+        "filename": "olmoe-1b-7b-compacted-5b.alloy.json",
+        "expected_alloy_hash_prefix": "bba0a92ff0c8bebb",
+        "ad_hoc_fields": [
+            "expert-activation-profile",
+            "expert-prune",
+            "calibrationCorpora",
+            "priorMetricBaselines",
+        ],
+    },
+    {
+        "repo": "continuum-ai/qwen2.5-coder-7b-compacted",
+        # Note: this artifact was renamed from v2-7b-coder-compensated; the
+        # alloy file inside the renamed repo retains the original name.
+        "filename": "v2-7b-coder-compensated.alloy.json",
+        "expected_alloy_hash_prefix": None,  # not enforced for legacy file name
+        "ad_hoc_fields": [],  # this one used dense head pruning, no MoE ad-hoc fields
+    },
+]
+
+HF_RAW_BASE = "https://huggingface.co/{repo}/raw/main/{filename}"
+
+
+def fetch_alloy(repo: str, filename: str) -> dict | None:
+    """Fetch a published alloy file from HF and return parsed JSON."""
+    url = HF_RAW_BASE.format(repo=repo, filename=filename)
+    try:
+        with urllib.request.urlopen(url, timeout=20) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        print(f"  HTTP {e.code} fetching {url}")
+        return None
+    except Exception as e:
+        print(f"  Error fetching {url}: {e}")
+        return None
+
+
+def has_field(obj: dict, path: str) -> bool:
+    """Walk a dotted path on an object."""
+    parts = path.split(".")
+    cur = obj
+    for p in parts:
+        if not isinstance(cur, dict) or p not in cur:
+            return False
+        cur = cur[p]
+    return True
+
+
+def collect_stage_types(alloy: dict) -> list[str]:
+    return [s.get("type") for s in alloy.get("stages", []) if isinstance(s, dict)]
+
+
+def validate_with_pydantic(alloy: dict) -> tuple[bool, str]:
+    """Try to load the alloy through forge_alloy.types.ForgeAlloy."""
+    try:
+        from forge_alloy.types import ForgeAlloy
+    except ImportError as e:
+        return False, f"forge_alloy not importable: {e}"
+    try:
+        # pydantic v2 API
+        instance = ForgeAlloy.model_validate(alloy)
+        # Round-trip with exclude_unset=True so fields the input didn't carry
+        # are NOT added to the output (e.g. calibrationCorpora defaults to []
+        # in the schema but published alloys without an upstream
+        # expert-activation-profile stage don't carry it). Fields actively
+        # set in the input round-trip back as themselves.
+        roundtripped = instance.model_dump(
+            by_alias=True, exclude_none=True, exclude_unset=True,
+        )
+        return True, f"validated; {len(roundtripped)} top-level keys"
+    except Exception as e:
+        return False, f"validation failed: {str(e)[:200]}"
+
+
+def semantic_equivalent(a: dict, b: dict) -> tuple[bool, str]:
+    """Check that two alloy dicts are semantically equivalent (deep-equal,
+    ignoring field ordering and int/float numeric equivalence). Returns
+    (ok, message).
+
+    int and float are considered equivalent when their numeric values
+    match — Pydantic coerces `12` (int in the published JSON) to `12.0`
+    (float, because the schema field is Optional[float]) on validation,
+    and the round-trip emits the float. Both are the same number; only
+    Python's type tag differs."""
+    def normalize(o):
+        if isinstance(o, dict):
+            return {k: normalize(v) for k, v in sorted(o.items())}
+        if isinstance(o, list):
+            return [normalize(x) for x in o]
+        # Coerce int/float to float so 12 == 12.0 in the structural compare.
+        if isinstance(o, (int, float)) and not isinstance(o, bool):
+            return float(o)
+        return o
+
+    na = normalize(a)
+    nb = normalize(b)
+    if na == nb:
+        return True, "deep-equal"
+
+    # Find first divergence (also normalize on the way down so the
+    # int/float coercion above propagates).
+    def _is_numeric(v):
+        return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+    def find_diff(x, y, path=""):
+        # int/float numeric equivalence is OK at the leaf
+        if _is_numeric(x) and _is_numeric(y):
+            if float(x) == float(y):
+                return None
+            return f"{path}: value diff ({x!r} vs {y!r})"
+        if type(x) != type(y):
+            return f"{path}: type mismatch ({type(x).__name__} vs {type(y).__name__})"
+        if isinstance(x, dict):
+            ka = set(x.keys())
+            kb = set(y.keys())
+            if ka != kb:
+                only_a = ka - kb
+                only_b = kb - ka
+                return f"{path}: key diff (only in input: {sorted(only_a)[:5]}, only in output: {sorted(only_b)[:5]})"
+            for k in sorted(ka):
+                d = find_diff(x[k], y[k], f"{path}.{k}")
+                if d:
+                    return d
+        elif isinstance(x, list):
+            if len(x) != len(y):
+                return f"{path}: list length {len(x)} vs {len(y)}"
+            for i, (xi, yi) in enumerate(zip(x, y)):
+                d = find_diff(xi, yi, f"{path}[{i}]")
+                if d:
+                    return d
+        else:
+            if x != y:
+                return f"{path}: value diff ({x!r} vs {y!r})"
+        return None
+
+    return False, find_diff(na, nb) or "unknown diff"
+
+
+def main():
+    print("=" * 70)
+    print("REGRESSION TEST — published continuum-ai alloys vs forge-alloy schema")
+    print("=" * 70)
+
+    pass_count = 0
+    fail_count = 0
+    failures = []
+
+    for spec in PUBLISHED_ALLOYS:
+        repo = spec["repo"]
+        filename = spec["filename"]
+        print(f"\n### {repo}")
+        print(f"  fetching {filename}")
+        alloy = fetch_alloy(repo, filename)
+        if alloy is None:
+            print(f"  FETCH FAILED — counting as test environment failure, not regression")
+            continue
+
+        # Show what's in the alloy
+        stages = collect_stage_types(alloy)
+        print(f"  stages ({len(stages)}): {stages}")
+        for ad_hoc in spec["ad_hoc_fields"]:
+            present = has_field(alloy, ad_hoc) or ad_hoc in stages
+            marker = "✓" if present else "✗"
+            print(f"  ad-hoc field expected: {marker} {ad_hoc}")
+
+        # Try to validate via pydantic
+        ok, msg = validate_with_pydantic(alloy)
+        print(f"  pydantic validation: {'PASS' if ok else 'FAIL'} — {msg}")
+
+        if ok:
+            # Round-trip semantic equivalence check
+            try:
+                from forge_alloy.types import ForgeAlloy
+                instance = ForgeAlloy.model_validate(alloy)
+                # Round-trip with exclude_unset=True so fields the input
+                # didn't carry are NOT added to the output (e.g.
+                # calibrationCorpora defaults to [] in the schema but
+                # published alloys without an upstream calibration stage
+                # don't carry it). exclude_none is OFF because some
+                # published alloys actively set fields like baselinePerplexity
+                # to null and the round-trip must preserve those nulls.
+                rt = instance.model_dump(
+                    by_alias=True, exclude_unset=True,
+                )
+                eq_ok, eq_msg = semantic_equivalent(alloy, rt)
+                print(f"  round-trip semantic equivalence: {'PASS' if eq_ok else 'FAIL'} — {eq_msg}")
+                if eq_ok:
+                    pass_count += 1
+                else:
+                    fail_count += 1
+                    failures.append((repo, "round-trip mismatch", eq_msg))
+            except Exception as e:
+                print(f"  round-trip exception: {e}")
+                fail_count += 1
+                failures.append((repo, "round-trip exception", str(e)))
+        else:
+            fail_count += 1
+            failures.append((repo, "validation", msg))
+
+    print()
+    print("=" * 70)
+    print(f"SUMMARY: {pass_count} passed, {fail_count} failed")
+    print("=" * 70)
+    if failures:
+        for repo, kind, msg in failures:
+            print(f"  ✗ {repo}: {kind}")
+            print(f"      {msg}")
+        print()
+        print("Regression test FAILED. Do not merge schema changes until")
+        print("all published alloys validate cleanly through the new schema.")
+        return 1
+    print("Regression test PASSED. All published alloys round-trip cleanly.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## TL;DR

Schema additions and relaxations needed by the sentinel-ai factory pipeline 2026-04-09 work (CambrianTech/sentinel-ai#169). Three changes, all backwards compatible with every existing published continuum-ai/* alloy.

## Changes

### 1. `AcceptanceCriteria` — the part spec, gate-as-alloy-field

New top-level optional field on `ForgeAlloy` and four new model classes:

- **`BenchmarkAcceptance`** — per-benchmark `min` (0..1), optional `anchorDelta` (the §4.1.3.4 discipline gate: forged score must be within Δ of the base anchor in the same eval pipeline), optional `anchorBenchmark`
- **`AcceptanceHardware`** — `maxVramGb`, `deviceTier`
- **`AcceptanceIntegrity`** — `modelHashRequired`, `samplesPathRequired`
- **`AcceptanceCriteria`** — top-level container with `benchmarks: dict[str, BenchmarkAcceptance]`, `hardware`, `integrity`

The alloy IS the part spec. In the assembly-line metaphor, every part has a spec sheet that travels with it down the line. AcceptanceCriteria is that spec — declared by the recipe author, self-contained in the alloy file. Sentinel-ai forges + assays; continuum (the shipping department) reads BOTH the assayed scores AND the alloy's `acceptanceCriteria` and decides ship vs rework.

### 2. `ExpertActivationProfileStage` — the §4.1.3.4 calibration-aware metric stage

Added to the discriminated `AlloyStage` union. Was missing from the schema even though the morning's qwen3-coder-30b-a3b-compacted-19b-256k flagship used it. This filled the gap so intent-only alloys with the calibration profile stage validate cleanly.

### 3. `TrainStage` — `domain`, `steps`, `learning_rate` made `Optional`

Was: required fields, the seeder had to hardcode default values.
Now: `Optional[T] = None`, the family adapter's `default_train_params(ctx)` hook fills them in at execution time.

The right architectural pattern: recipes declare INTENT (`{type: train, method: lora}`), the family adapter knows what works for its architecture and model size, fills in domain/steps/LR/etc. at runtime. Recipe authors override only when they want to override.

Backwards compat: every existing alloy that DOES specify `domain/steps/learningRate` still validates and the values are still used as-is. The Optional change only affects intent-only alloys.

## Tests

```
25 passed (+8 new for AcceptanceCriteria and TrainStage Optional behavior)
```

## Companion PR

Sentinel-ai side: **CambrianTech/sentinel-ai#169** — uses these schema changes via the `forge_alloy.types.AcceptanceCriteria` import in `seed_factory_queue.py` and the family adapter's `default_train_params()` hook in `alloy_executor.py` + `transform_stages.py`.