### PR TITLE
fix: attestation CI deps + verify page fallback

### DIFF
--- a/.github/workflows/attest-main.yml
+++ b/.github/workflows/attest-main.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install QR dependency
-        run: pip install qrcode
+      - name: Install dependencies
+        run: pip install pydantic qrcode
 
       - name: Compute attestation chain + generate badge
         run: |

--- a/.github/workflows/attest-pr.yml
+++ b/.github/workflows/attest-pr.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install dependencies
+        run: pip install pydantic
+
       - name: Compute PR attestation chain
         id: chain
         run: |

--- a/docs/verify/index.html
+++ b/docs/verify/index.html
@@ -238,11 +238,12 @@ async function verify() {
       console.error('HF search failed:', e);
     }
     // Fallback: check this repo's own attestation chain (dogfood)
+    // raw.githubusercontent.com supports CORS natively — no proxy needed
     if (!url) {
-      statusEl.querySelector('.status-detail').textContent = 'Checking repo self-attestation…';
+      statusEl.innerHTML = '<div class="status-icon">⏳</div><div class="status-text">Checking repo self-attestation…</div><div class="status-detail">Fetching chain from GitHub…</div>';
       try {
         const chainUrl = 'https://raw.githubusercontent.com/CambrianTech/forge-alloy/main/.attestation/chain.json';
-        const resp = await fetchWithProxy(chainUrl);
+        const resp = await fetch(chainUrl);
         if (resp.ok) {
           const txt = await resp.text();
           const data = JSON.parse(txt);


### PR DESCRIPTION
## Summary
- Add `pydantic` to CI install steps (both workflows) — `__init__.py` imports `types.py` which needs it
- Fix verify page GitHub fallback: use direct `fetch()` for `raw.githubusercontent.com` (supports CORS natively, no proxy needed)
- Fix null element reference in fallback status update

Fixes the "Alloy not found" error when scanning the README QR code.

## Test plan
- [ ] CI workflows pass (both PR and main attestation)
- [ ] Verify page resolves `#76654a5661006320` via GitHub fallback